### PR TITLE
P2S compat

### DIFF
--- a/config.example.py
+++ b/config.example.py
@@ -1,2 +1,3 @@
 #!/usr/bin/env python3
 macaddress = "00:11:22:33:44:55"
+width = 384

--- a/hardware.py
+++ b/hardware.py
@@ -46,7 +46,7 @@ class Paperang:
     def scandevices(self):
         logging.warning("Searching for devices...\n"
                         "This will take some time; consider specifing a mac address to avoid a scan.")
-        valid_names = ['MiaoMiaoJi', 'Paperang']
+        valid_names = ['MiaoMiaoJi', 'Paperang', 'Paperang_P2S']
         nearby_devices = discover_devices(lookup_names=True)
         valid_devices = list(filter(lambda d: len(d) == 2 and d[1] in valid_names, nearby_devices))
         if len(valid_devices) == 0:
@@ -98,10 +98,14 @@ class Paperang:
         # print("printing service matches...")
         # print(service_matches)
         # print("...done.")
-        if len(service_matches) == 0:
+        valid_services = list(filter(
+            lambda s: 'name' in s and s['name'] == 'SerialPort',
+            service_matches
+        ))
+        if len(valid_services) == 0:
             logging.error("Cannot find valid services on device with MAC %s." % self.address)
             return False
-        self.service = service_matches[0]
+        self.service = valid_services[0]
         return True        
 
     def sendMsgAllPackage(self, msg):
@@ -183,7 +187,7 @@ class Paperang:
         self.sendPaperTypeToBt()
         # msg = struct.pack("<%dc" % len(binary_img), *map(bytes, binary_img))
         msg = b"".join(map(lambda x: struct.pack("<c",x.to_bytes(1,byteorder="little")),binary_img))
-        print(msg)
+        # print(msg)
         self.sendToBt(msg, BtCommandByte.PRT_PRINT_DATA, need_reply=False)
         self.sendFeedLineToBt(self.padding_line)
 

--- a/image_data.py
+++ b/image_data.py
@@ -7,6 +7,7 @@ import skimage as ski
 import pilkit.processors
 from PIL import Image, ImageFilter, ImageOps, ImageEnhance
 import numba
+import config
 
 
 def _pack_block(bits_str: str) -> bytearray:
@@ -28,6 +29,8 @@ def binimage2bitstream(bin_image: np.ndarray):
 def im2binimage(im, conversion="threshold"):
     # convert standard numpy array image to bin_image
     fixed_width = 384
+    if hasattr(config, "width"):
+        fixed_width = config.width
     if (len(im.shape) != 2):
         im = ski.color.rgb2gray(im)
     im = ski.transform.resize(im, (round( fixed_width /im.shape[1]  * im.shape[0]), fixed_width))


### PR DESCRIPTION
I got this (mostly) working with my P2S, here's what it needed:

- config for customisable width value
- valid name value `Paperang_P2S` (I guess we could fuzzy match on `paperang*` if this keeps being an issue)
- check explicitly for `SerialPort` service. Not sure if it's new to P2S, but there's also a WeChat service which often takes priority, but the printer doesn't listen to print commands on that channel

🐍🖨️